### PR TITLE
Tagline searching

### DIFF
--- a/src/Config.cs
+++ b/src/Config.cs
@@ -7,7 +7,7 @@ public class Config : BasePluginConfiguration
     public static readonly string[] DefaultAttributesToSearchOn =
     [
         "name", "artists", "albumArtists", "originalTitle", "productionYear", "seriesName", "genres", "tags",
-        "studios", "overview", "path"
+        "studios", "overview", "path", "tagline"
     ];
 
     public Config()

--- a/src/DbIndexer.cs
+++ b/src/DbIndexer.cs
@@ -36,7 +36,7 @@ public class DbIndexer(
                 Name, Overview, ProductionYear, Genres, 
                 Studios, Tags, IsFolder, CriticRating, 
                 OriginalTitle, SeriesName, Artists, 
-                AlbumArtists, Path 
+                AlbumArtists, Path, Tagline
             FROM 
                 BaseItems
             """;
@@ -62,7 +62,8 @@ public class DbIndexer(
                 SeriesName: !reader.IsDBNull(13) ? reader.GetString(13) : null,
                 Artists: !reader.IsDBNull(14) ? reader.GetString(14).Split('|') : null,
                 AlbumArtists: !reader.IsDBNull(15) ? reader.GetString(15).Split('|') : null,
-                Path: !reader.IsDBNull(16) ? reader.GetString(16) : null
+                Path: !reader.IsDBNull(16) ? reader.GetString(16) : null,
+                Tagline: !reader.IsDBNull(17) ? reader.GetString(17) : null
             );
             if (item.Path?[0] == '%') item = item with { Path = null };
             items.Add(item);

--- a/src/EFCoreIndexer.cs
+++ b/src/EFCoreIndexer.cs
@@ -40,7 +40,8 @@ public class EfCoreIndexer(
             Artists: item.Artists?.Split('|'),
             AlbumArtists: item.AlbumArtists?.Split('|'),
             CriticRating: item.CriticRating,
-            IsFolder: item.IsFolder
+            IsFolder: item.IsFolder,
+            Tagline: item.Tagline
         );
     }
 }

--- a/src/MeilisearchItem.cs
+++ b/src/MeilisearchItem.cs
@@ -17,5 +17,6 @@ public record MeilisearchItem(
     bool? IsFolder,
     double? CommunityRating,
     double? CriticRating,
-    string? Path
+    string? Path,
+    string? Tagline
 );

--- a/src/config.html
+++ b/src/config.html
@@ -123,7 +123,8 @@
                 "name", "artists", "albumArtists",
                 "originalTitle", "productionYear",
                 "seriesName", "genres", "tags",
-                "studios", "overview", "path"
+                "studios", "overview", "path",
+                "tagline"
             ]
             const generateCheckboxList = (checked) => {
                 const checkboxList = document.getElementById("checkbox-list");


### PR DESCRIPTION
Addresses https://github.com/arnesacnussem/jellyfin-plugin-meilisearch/issues/50 with the caveat that users will need to go into the plugin settings and select "Tagline" explicitly:

<img width="820" height="504" alt="image" src="https://github.com/user-attachments/assets/aeb8b77a-94d7-4000-9de6-d4613a334d04" />

Also requires a reindex, but that's pretty fast.