### PR TITLE
Only search once per request

### DIFF
--- a/src/MeilisearchMutateFilter.cs
+++ b/src/MeilisearchMutateFilter.cs
@@ -136,20 +136,25 @@ public class MeilisearchMutateFilter(
         try
         {
             var additionQuery = additionalFilters.Select(it => $"{it.Key} = {it.Value}").ToList();
-            var additionQueryStr = additionQuery.Count > 0 ? $" AND {string.Join(" AND ", additionQuery)}" : "";
-            foreach (var itemType in itemTypes)
-            {
-                var results = await index.SearchAsync<MeilisearchItem>(
-                    searchTerm,
-                    new SearchQuery
-                    {
-                        Filter = $"type = \"{itemType}\" {additionQueryStr}",
-                        Limit = limitPerType,
-                        AttributesToSearchOn = Plugin.Instance?.Configuration.AttributesToSearchOn
-                    }
-                );
-                items.AddRange(results.Hits);
-            }
+            var additionQueryStr = string.Join(" AND ", additionQuery);
+            var itemTypeFilter = itemTypes.Select(it => $"type = \"{it}\"").ToList();
+            var itemTypeFilterStr = string.Join(" OR ", itemTypeFilter);
+
+            var filter = "";
+            if(additionQuery.Count > 0 && itemTypes.Count > 0) filter = $"({itemTypeFilterStr}) AND {additionQueryStr}";
+            else if(additionQuery.Count > 0) filter = additionQueryStr;
+            else if(itemTypes.Count > 0) filter = itemTypeFilterStr;
+
+            var results = await index.SearchAsync<MeilisearchItem>(
+                searchTerm,
+                new SearchQuery
+                {
+                    Filter = filter,
+                    Limit = limitPerType,
+                    AttributesToSearchOn = Plugin.Instance?.Configuration.AttributesToSearchOn
+                }
+            );
+            items.AddRange(results.Hits);
         }
         catch (MeilisearchCommunicationError e)
         {

--- a/src/MeilisearchMutateFilter.cs
+++ b/src/MeilisearchMutateFilter.cs
@@ -145,12 +145,13 @@ public class MeilisearchMutateFilter(
             else if (additionQuery.Count > 0) filter = additionQueryStr;
             else if (itemTypes.Count > 0) filter = itemTypeFilterStr;
 
+            var totalLimit = limitPerType;
             var results = await index.SearchAsync<MeilisearchItem>(
                 searchTerm,
                 new SearchQuery
                 {
                     Filter = filter,
-                    Limit = limitPerType,
+                    Limit = totalLimit,
                     AttributesToSearchOn = Plugin.Instance?.Configuration.AttributesToSearchOn
                 }
             );

--- a/src/MeilisearchMutateFilter.cs
+++ b/src/MeilisearchMutateFilter.cs
@@ -141,9 +141,9 @@ public class MeilisearchMutateFilter(
             var itemTypeFilterStr = string.Join(" OR ", itemTypeFilter);
 
             var filter = "";
-            if(additionQuery.Count > 0 && itemTypes.Count > 0) filter = $"({itemTypeFilterStr}) AND {additionQueryStr}";
-            else if(additionQuery.Count > 0) filter = additionQueryStr;
-            else if(itemTypes.Count > 0) filter = itemTypeFilterStr;
+            if (additionQuery.Count > 0 && itemTypes.Count > 0) filter = $"({itemTypeFilterStr}) AND {additionQueryStr}";
+            else if (additionQuery.Count > 0) filter = additionQueryStr;
+            else if (itemTypes.Count > 0) filter = itemTypeFilterStr;
 
             var results = await index.SearchAsync<MeilisearchItem>(
                 searchTerm,

--- a/src/MeilisearchMutateFilter.cs
+++ b/src/MeilisearchMutateFilter.cs
@@ -140,7 +140,7 @@ public class MeilisearchMutateFilter(
             var itemTypeFilter = itemTypes.Select(it => $"type = \"{it}\"").ToList();
             var itemTypeFilterStr = string.Join(" OR ", itemTypeFilter);
 
-            var filter = "";
+            var filter = string.Empty;
             if (additionQuery.Count > 0 && itemTypes.Count > 0) filter = $"({itemTypeFilterStr}) AND {additionQueryStr}";
             else if (additionQuery.Count > 0) filter = additionQueryStr;
             else if (itemTypes.Count > 0) filter = itemTypeFilterStr;

--- a/src/MeilisearchMutateFilter.cs
+++ b/src/MeilisearchMutateFilter.cs
@@ -129,7 +129,7 @@ public class MeilisearchMutateFilter(
         string searchTerm,
         List<string> itemTypes,
         List<KeyValuePair<string, string>> additionalFilters,
-        int limitPerType
+        int totalLimit
     )
     {
         List<MeilisearchItem> items = [];
@@ -150,7 +150,7 @@ public class MeilisearchMutateFilter(
                 new SearchQuery
                 {
                     Filter = filter,
-                    Limit = limitPerType,
+                    Limit = totalLimit,
                     AttributesToSearchOn = Plugin.Instance?.Configuration.AttributesToSearchOn
                 }
             );
@@ -251,13 +251,12 @@ public class MeilisearchMutateFilter(
             }
         }
 
+        //Default limit to 30 per type if it's not defined
         var limit = context.ActionArguments.TryGetValue("limit", out var limitObj)
             ? (int)limitObj!
-            : 0;
-        var limitPreItem = filteredTypes.Count > 0 && limit > 0
-            ? Math.Clamp(limit / filteredTypes.Count, 30, 100)
-            : 30;
-        var meilisearchItems = await Search(ch.Index, searchTerm, filteredTypes, additionalFilters, limitPreItem);
+            : 30 * filteredTypes.Count;
+
+        var meilisearchItems = await Search(ch.Index, searchTerm, filteredTypes, additionalFilters, limit);
 
         // remove items that are not visible to the user
         var items = meilisearchItems.Select(it =>


### PR DESCRIPTION
I noticed that the plugin loops through each media type requested and performs a separate Meilisearch search for each one. This PR rewrites the Search() method to use [Meilisearch's filter syntax](https://www.meilisearch.com/docs/learn/filtering_and_sorting/filter_search_results) instead, which has the same effect of filtering for any of the applicable media types.

This is my first PR in C#, and I couldn't find any contribution guidelines, so please feel free to let me know if there's anything at all I can do to improve it! Thanks