### PR TITLE
feat: add configurable matchingStrategy for Meilisearch queries

### DIFF
--- a/src/Config.cs
+++ b/src/Config.cs
@@ -10,6 +10,7 @@ public class Config : BasePluginConfiguration
         Url = string.Empty;
         Debug = false;
         IndexName = string.Empty;
+        MatchingStrategy = "last";
     }
 
     public string ApiKey { get; set; }
@@ -17,4 +18,9 @@ public class Config : BasePluginConfiguration
 
     public bool Debug { get; set; }
     public string IndexName { get; set; }
+
+    /// <summary>
+    /// Meilisearch matchingStrategy: "last", "all", or "frequency".
+    /// </summary>
+    public string MatchingStrategy { get; set; }
 }

--- a/src/MeilisearchRepositoryDecorator.cs
+++ b/src/MeilisearchRepositoryDecorator.cs
@@ -42,12 +42,14 @@ public class MeilisearchRepositoryDecorator(
         var typeFilter = string.Join(" OR ", types.Select(t => $"type = \"{t}\""));
         try
         {
+            var matchingStrategy = Plugin.Instance?.Configuration.MatchingStrategy ?? "last";
             var result = await clientHolder.Index!.SearchAsync<MeilisearchItem>(
                 filter.SearchTerm,
                 new SearchQuery
                 {
                     Filter = typeFilter,
                     Limit = limit,
+                    MatchingStrategy = matchingStrategy,
                 }
             );
             List<Guid> ids = [];

--- a/src/config.html
+++ b/src/config.html
@@ -82,6 +82,15 @@
                     <input id="IndexName" is="emby-input" name="IndexName" type="text"/>
                     <div class="fieldDescription">Default to server friendly name.</div>
                 </div>
+                <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="MatchingStrategy">Matching Strategy</label>
+                    <select id="MatchingStrategy" is="emby-select" name="MatchingStrategy">
+                        <option value="last">last (default — return results with most keywords matched)</option>
+                        <option value="all">all — only return results matching every keyword</option>
+                        <option value="frequency">frequency — prioritise words appearing less frequently</option>
+                    </select>
+                    <div class="fieldDescription">Controls how Meilisearch matches search keywords.</div>
+                </div>
                 <div class="checkboxContainer checkboxContainer-withDescription">
                     <label class="emby-checkbox-label">
                         <input id="Debug" is="emby-checkbox" name="Debug" type="checkbox"/>
@@ -149,6 +158,7 @@
                         document.querySelector('#ApiKey').value = config.ApiKey;
                         document.querySelector('#Debug').checked = config.Debug;
                         document.querySelector('#IndexName').value = config.IndexName;
+                        document.querySelector('#MatchingStrategy').value = config.MatchingStrategy || 'last';
                         Dashboard.hideLoadingMsg();
                     });
                     updateStatus('status');
@@ -162,6 +172,7 @@
                         config.ApiKey = document.querySelector('#ApiKey').value;
                         config.Debug = document.querySelector('#Debug').checked;
                         config.IndexName = document.querySelector('#IndexName').value;
+                        config.MatchingStrategy = document.querySelector('#MatchingStrategy').value;
                         ApiClient.updatePluginConfiguration(id, config).then(result => {
                             Dashboard.processPluginConfigurationUpdateResult(result);
                         });


### PR DESCRIPTION
Adds a MatchingStrategy config option (last/all/frequency) that is passed to Meilisearch search queries, allowing users to require all keywords to appear in results by selecting "all".