### PR TITLE
fix(config): build status URL with ApiClient.getUrl for base-path installs

### DIFF
--- a/src/config.html
+++ b/src/config.html
@@ -126,7 +126,7 @@
                 reindexBtn.className = clsNameDisabled;
 
                 statusEl.innerText = 'loading status...';
-                ApiClient.getJSON('/meilisearch/' + endpoint).then(status => {
+                ApiClient.getJSON(ApiClient.getUrl('meilisearch/' + endpoint)).then(status => {
                     statusEl.innerText = JSON.stringify(status, null, 2);
                     if (status.meilisearchOk) {
                         reconnectBtn.style.display = 'none';


### PR DESCRIPTION
Fixes #132

## Summary

Fixes the config page's status fetch on Jellyfin instances served under a **base URL / base path**.

The page requested the status endpoint with a root-relative path:

```js
ApiClient.getJSON('/meilisearch/' + endpoint)
```

On an instance with `<BaseUrl>/jellyfin</BaseUrl>`, the leading slash bypasses the base path and hits the web root, which returns a **302 redirect to the SPA** (HTML body). `getJSON` then fails with:

```
JSON.parse: unexpected character at line 1 column 1 of the JSON data
```

## Change

Route the request through `ApiClient.getUrl()`, which prepends the server address and base path, so it reaches `/<base>/meilisearch/<endpoint>`:

```diff
- ApiClient.getJSON('/meilisearch/' + endpoint).then(status => {
+ ApiClient.getJSON(ApiClient.getUrl('meilisearch/' + endpoint)).then(status => {
```

Installs without a base path are unaffected (`getUrl` just returns the origin-rooted URL).

## Testing

Verified on Jellyfin 10.11.11 (Docker, base path `/jellyfin`): before the change `GET /meilisearch/status` returned 302→HTML; after the change the page requests `/jellyfin/meilisearch/status`, which is the real endpoint (401 without a token, JSON with one). Built against `Jellyfin.Controller` 10.11.7 / net9.0 and loaded successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019k8SpMiQYBq9oQSD9xGzqz
