### PR TITLE
fix: reload on IndexName change, real search timing, drop conn-string leak

### DIFF
--- a/src/EfCoreIndexer.cs
+++ b/src/EfCoreIndexer.cs
@@ -15,7 +15,6 @@ public class EfCoreIndexer(
     protected override async Task<ImmutableList<MeilisearchItem>> GetItems(IReadOnlySet<string> includedTypes)
     {
         using var context = dbProvider.DbContextFactory!.CreateDbContext();
-        Status["Database"] = context.Database.GetDbConnection().ConnectionString;
 
         var entities = await context.BaseItems
             .AsNoTracking()

--- a/src/MeilisearchSearchProvider.cs
+++ b/src/MeilisearchSearchProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -103,8 +104,11 @@ public class MeilisearchSearchProvider : IExternalSearchProvider
             MatchingStrategy = matchingStrategy,
         };
 
+        var stopwatch = Stopwatch.StartNew();
         var result = await index.SearchAsync<MeilisearchSearchHit>(
             searchTerm, searchQuery, cancellationToken).ConfigureAwait(false);
+        stopwatch.Stop();
+        Plugin.Instance?.UpdateAverageSearchTime(stopwatch.ElapsedMilliseconds);
 
         var results = new List<(Guid, float)>(result.Hits.Count);
         foreach (var hit in result.Hits)

--- a/src/Plugin.cs
+++ b/src/Plugin.cs
@@ -65,7 +65,9 @@ public class Plugin : BasePlugin<Config>, IHasWebPages
     {
         ArgumentNullException.ThrowIfNull(configuration);
         var config = (Config)configuration;
-        var skipReload = Configuration.Url == config.Url && Configuration.ApiKey == config.ApiKey;
+        var skipReload = Configuration.Url == config.Url
+                         && Configuration.ApiKey == config.ApiKey
+                         && Configuration.IndexName == config.IndexName;
 
         Configuration = config;
         SaveConfiguration(Configuration);
@@ -123,8 +125,9 @@ public class Plugin : BasePlugin<Config>, IHasWebPages
     {
         lock (this)
         {
-            if (AverageSearchTime == 0) AverageSearchTime = averageSearchTime;
-            AverageSearchTime = (averageSearchTime + AverageSearchTime) / 2;
+            AverageSearchTime = AverageSearchTime == 0
+                ? averageSearchTime
+                : (averageSearchTime + AverageSearchTime) / 2;
         }
     }
 }


### PR DESCRIPTION
## Summary

Three small, independent fixes found while reviewing the plugin.

### 1. Reload the client when `IndexName` changes
`Plugin.UpdateConfiguration` only compared `Url` and `ApiKey` when deciding whether to reload, so changing the **index name** in config had no effect until Jellyfin restarted (searches/indexing kept using the old index). `IndexName` is now part of the comparison.

### 2. `averageSearchTime` is now actually measured
`UpdateAverageSearchTime()` had **no callers**, so the status endpoint always reported `0ms`. `MeilisearchSearchProvider` now times the Meilisearch call with a `Stopwatch` and reports it. Also simplified the redundant EMA seed in `UpdateAverageSearchTime` (the `if (== 0)` assignment was immediately overwritten by the next line).

### 3. Don't expose the DB connection string via `/meilisearch/status`
`EfCoreIndexer` wrote `context.Database.GetDbConnection().ConnectionString` into `Status["Database"]`, which is returned by the status endpoint. Connection strings can carry credentials, so this is removed.

## Notes

- Admin-gated endpoint, so #3 is low severity, but there's no reason to echo it.
- Changes are self-contained; `Stopwatch` is the only new dependency (`System.Diagnostics`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019k8SpMiQYBq9oQSD9xGzqz
